### PR TITLE
feat: add `__DATA` macro for C51 `data` and SDCC `__data`

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -103,6 +103,7 @@ __CX51__, __CONF_MCU_MODEL=MCU_MODEL_STC8H3K32S2,__CONF_FOSC=36864000UL
 | Macro | Keil C51 | SDCC |
 | ----------- | ---------------- | ----------------- |
 | __BIT | bit | __bit |
+| __DATA  | data  | __data  |
 | __IDATA | idata | __idata |
 | __PDATA | pdata | __pdata |
 | __XDATA | xdata | __xdata |

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Here is a list of the macros:
 | Macro | Keil C51 | SDCC |
 | ----------- | ---------------- | ----------------- |
 | __BIT | bit | __bit |
+| __DATA  | data  | __data  |
 | __IDATA | idata | __idata |
 | __PDATA | pdata | __pdata |
 | __XDATA | xdata | __xdata |

--- a/include/fw_reg_base.h
+++ b/include/fw_reg_base.h
@@ -20,6 +20,7 @@
     #include <lint.h>
     # warning unrecognized compiler
     #define __BIT   bool
+    #define __DATA
     #define __IDATA
     #define __PDATA 
     #define __XDATA 
@@ -35,6 +36,7 @@
 
 #elif defined (SDCC) || defined (__SDCC)
     #define __BIT   __bit
+    #define __DATA  __data
     #define __IDATA __idata
     #define __PDATA __pdata
     #define __XDATA __xdata
@@ -51,6 +53,7 @@
 
 #elif defined __CX51__
     #define __BIT   bit
+    #define __DATA  data
     #define __IDATA idata
     #define __PDATA pdata
     #define __XDATA xdata


### PR DESCRIPTION
This PR proposes to add a `__DATA` macro to `fw_reg_base.h` so that explicit placement declaration in DATA segment can be done compiler-independently.

Relevant documentation pages are also updated in this PR.