### PR TITLE
Update fw_types.h for compatibility of stdint.h

### DIFF
--- a/include/fw_types.h
+++ b/include/fw_types.h
@@ -15,6 +15,9 @@
 #ifndef ___FW_TYPES_H___
 #define ___FW_TYPES_H___
 
+#if defined (SDCC) || defined (__SDCC)
+#include <stdint.h>
+#else
 typedef unsigned char uint8_t;
 typedef unsigned short uint16_t;
 typedef unsigned long uint32_t;
@@ -24,6 +27,7 @@ typedef signed char int8_t;
 typedef short int16_t;
 typedef long int32_t;
 typedef int32_t int64_t[2];
+#endif
 
 
 #define B00000000   0x00


### PR DESCRIPTION
The stdint.h will be used if compiler (SDCC) has internal support. 