### PR TITLE
fix: UART1_AlterPort_t values, UART2_SwitchPort reg mistype

### DIFF
--- a/include/fw_uart.h
+++ b/include/fw_uart.h
@@ -44,8 +44,8 @@ typedef enum
 {
     UART1_AlterPort_P30_P31      = 0x00,
     UART1_AlterPort_P36_P37      = 0x01,
-    UART1_AlterPort_P16_P17      = 0x10,
-    UART1_AlterPort_P43_P44      = 0x11,
+    UART1_AlterPort_P16_P17      = 0x02,
+    UART1_AlterPort_P43_P44      = 0x03,
 } UART1_AlterPort_t;
 
 #define UART1_SetRxState(__STATE__)         SBIT_ASSIGN(REN, __STATE__)
@@ -115,7 +115,7 @@ typedef enum
 /**
  * Alternative port selection: P10:rx/P11:tx, P46:rx/P47:tx
 */
-#define UART2_SwitchPort(__ALTER_PORT__)    (P_SW2 = P_SW1 & ~(0x01 << 0) | ((__ALTER_PORT__) << 0))
+#define UART2_SwitchPort(__ALTER_PORT__)    (P_SW2 = P_SW2 & ~(0x01 << 0) | ((__ALTER_PORT__) << 0))
 /**
  * Dynamic baud-rate, provided by Timer2
 */


### PR DESCRIPTION
Fixed simple typos.

Thanks for your work!